### PR TITLE
Refactor method to check OpenCL errors

### DIFF
--- a/src/exceptions/ResourceException.h
+++ b/src/exceptions/ResourceException.h
@@ -30,5 +30,5 @@
 
 class ResourceException : public std::runtime_error {
 public:
-    ResourceException(std::string message) : std::runtime_error(message) {};
+    ResourceException(std::string message) : std::runtime_error(message) {}
 };

--- a/src/exceptions/ResultException.h
+++ b/src/exceptions/ResultException.h
@@ -26,6 +26,9 @@
 
 #pragma once
 
-class ResultException : public std::exception {
-    ResultException(std::string message) : std::exception(message) {}
+#include <stdexcept>
+
+class ResultException : public std::runtime_error {
+public:
+    ResultException(std::string message) : std::runtime_error(message) {}
 };

--- a/src/platform/Helper.cpp
+++ b/src/platform/Helper.cpp
@@ -35,6 +35,8 @@
 #include <fstream>
 #include <cstring>
 #include <algorithm>
+#include <ResultException.h>
+#include <ResourceException.h>
 
 #include "Helper.h"
 
@@ -361,14 +363,19 @@ namespace helper {
     }
     // LCOV_EXCL_STOP
 
-    void CheckError(cl_int error) {
+    template<typename T>
+    void CheckError(cl_int error, const std::string &message) {
         if (error != CL_SUCCESS) {
-            // LCOV_EXCL_START
-            std::cerr << "OpenCL call failed with error " << getErrorString(error) << std::endl;
-            std::exit(1);
-            // LCOV_EXCL_STOP
+            throw T(message + " OpenCL message: " + getErrorString(error)); // LCOV_EXCL_LINE
         }
     }
+
+    // Explicit instantiation
+    template void
+    CheckError<ResultException>(cl_int error, const std::string &message);
+
+    template void
+    CheckError<ResourceException>(cl_int error, const std::string &message);
 
     std::string LoadKernel(const char *name) {
         std::ifstream in(name);
@@ -383,7 +390,7 @@ namespace helper {
 
         cl_int error = 0;
         cl_program program = clCreateProgramWithSource (context, 1, sources, lengths, &error);
-        helper::CheckError (error);
+        helper::CheckError<ResourceException>(error, "Failed to create program.");
 
         return program;
     }

--- a/src/platform/Helper.h
+++ b/src/platform/Helper.h
@@ -132,9 +132,24 @@ namespace helper {
     template<typename Dtype>
     void add_bias(Dtype *data_matrix, const Dtype *bias, int number_of_rows, int number_of_columns);
 
+    /**
+     * Returns the corresponding OpenCL error message for a given OpenCL error code.
+     *
+     * @param error                 The OpenCL error code of a OpenCL function.
+     * @return                      Returns the corresponding OpenCL error message.
+     */
     const char *getErrorString(cl_int error);
 
-    void CheckError(cl_int error);
+    /**
+     * Takes the return code of a OpenCL function and checks whether the OpenCL function was successful.
+     * If the OpenCL function was not succesful, an exception of kind @T with the message @message is thrown.
+     *
+     * @tparam T        The kind of exception that should be thrown in case a OpenCL function was not successful.
+     * @param error     The OpenCL error code returned by a OpenCL function.
+     * @param message   A user-defined descriptive error message that will be the exception message.
+     */
+    template<typename T>
+    void CheckError(cl_int error, const std::string &message);
 
     std::string LoadKernel (const char* name);
 

--- a/src/platform/Helper.h
+++ b/src/platform/Helper.h
@@ -151,7 +151,242 @@ namespace helper {
     template<typename T>
     void CheckError(cl_int error, const std::string &message);
 
-    std::string LoadKernel (const char* name);
+    /**
+     *
+     *
+     * @param name
+     * @return
+     */
+    std::string LoadKernel(const char *name);
 
-    cl_program CreateProgram (const std::string& source, cl_context context);
+    /**
+     *
+     *
+     * @param source
+     * @param context
+     * @return
+     */
+    cl_program CreateProgram(const std::string &source, cl_context context);
+
+// Host allocation functions
+    void *alignedMalloc(size_t size);
+
+    void alignedFree(void *ptr);
+
+
+// Sets the current working directory to the same directory that contains
+// this executable. Returns true on success.
+    bool setCwdToExeDir();
+
+// Find a platform that contains the search string in its name (case-insensitive match).
+// Returns NULL if no match is found.
+    cl_platform_id findPlatform(const char *platform_name_search);
+
+// Returns the name of the platform.
+    std::string getPlatformName(cl_platform_id pid);
+
+// Returns the name of the device.
+    std::string getDeviceName(cl_device_id did);
+
+// Returns an array of device ids for the given platform and the
+// device type.
+// Return value must be freed with delete[].
+    cl_device_id *getDevices(cl_platform_id pid, cl_device_type dev_type, cl_uint *num_devices);
+
+// Create a OpenCL program from a binary file.
+// The program is created for all given devices associated with the context. The same
+// binary is used for all devices.
+    cl_program createProgramFromBinary(cl_context context, const char *binary_file_name, const cl_device_id *devices,
+                                       unsigned num_devices);
+
+// Load binary file.
+// Return value must be freed with delete[].
+    unsigned char *loadBinaryFile(const char *file_name, size_t *size);
+
+// Checks if a file exists.
+    bool fileExists(const char *file_name);
+
+// Returns the path to the AOCX file to use for the given device.
+// This is special handling for examples for the Altera SDK for OpenCL.
+// It uses the device name to get the board name and then looks for a
+// corresponding AOCX file. Specifically, it gets the device name and
+// extracts the board name assuming the device name has the following format:
+//  <board> : ...
+//
+// Then the AOCX file is <prefix>_<version>_<board>.aocx. If this
+// file does not exist, then the file name defaults to <prefix>.aocx.
+    std::string getBoardBinaryFile(const char *prefix, cl_device_id device);
+
+// Returns the time from a high-resolution timer in seconds. This value
+// can be used with a value returned previously to measure a high-resolution
+// time difference.
+    double getCurrentTimestamp();
+
+// Returns the difference between the CL_PROFILING_COMMAND_END and
+// CL_PROFILING_COMMAND_START values of a cl_event object.
+// This requires that the command queue associated with the event be created
+// with the CL_QUEUE_PROFILING_ENABLE property.
+//
+// The return value is in nanoseconds.
+    cl_ulong getStartEndTime(cl_event event);
+
+// Wait for the specified number of milliseconds.
+    void waitMilliseconds(unsigned ms);
+
+// Smart pointers.
+// Interface is essentially the combination of std::auto_ptr and boost's smart pointers,
+// along with some small extensions (auto conversion to T*).
+
+// scoped_ptr: assumes pointer was allocated with operator new; destroys with operator delete
+    template<typename T>
+    class scoped_ptr {
+    public:
+        typedef scoped_ptr<T> this_type;
+
+        scoped_ptr() : m_ptr(NULL) {}
+
+        scoped_ptr(T *ptr) : m_ptr(ptr) {}
+
+        ~scoped_ptr() { reset(); }
+
+        T *get() const { return m_ptr; }
+
+        operator T *() const { return m_ptr; }
+
+        T *operator->() const { return m_ptr; }
+
+        T &operator*() const { return *m_ptr; }
+
+        this_type &operator=(T *ptr) {
+            reset(ptr);
+            return *this;
+        }
+
+        void reset(T *ptr = NULL) {
+            delete m_ptr;
+            m_ptr = ptr;
+        }
+
+        T *release() {
+            T *ptr = m_ptr;
+            m_ptr = NULL;
+            return ptr;
+        }
+
+    private:
+        T *m_ptr;
+
+        // noncopyable
+        scoped_ptr(const this_type &);
+
+        this_type &operator=(const this_type &);
+    };
+
+
+    // scoped_array: assumes pointer was allocated with operator new[]; destroys with operator delete[]
+    // Also supports allocation/reset with a number, which is the number of
+    // elements of type T.
+    template<typename T>
+    class scoped_array {
+    public:
+        typedef scoped_array<T> this_type;
+
+        scoped_array() : m_ptr(NULL) {}
+
+        explicit scoped_array(T *ptr) : m_ptr(NULL) { reset(ptr); }
+
+        explicit scoped_array(size_t n) : m_ptr(NULL) { reset(n); }
+
+        ~scoped_array() { reset(); }
+
+        T *get() const { return m_ptr; }
+
+        explicit operator T *() const { return m_ptr; }
+
+        T *operator->() const { return m_ptr; }
+
+        T &operator*() const { return *m_ptr; }
+
+        T &operator[](int index) const { return m_ptr[index]; }
+
+        this_type &operator=(T *ptr) {
+            reset(ptr);
+            return *this;
+        }
+
+        void reset(T *ptr = NULL) {
+            delete[] m_ptr;
+            m_ptr = ptr;
+        }
+
+        void reset(size_t n) { reset(new T[n]); }
+
+        T *release() {
+            T *ptr = m_ptr;
+            m_ptr = NULL;
+            return ptr;
+        }
+
+    private:
+        T *m_ptr;
+
+        // noncopyable
+        scoped_array(const this_type &);
+
+        this_type &operator=(const this_type &);
+    };
+
+
+// scoped_aligned_ptr: assumes pointer was allocated with alignedMalloc; destroys with alignedFree
+// Also supports allocation/reset with a number, which is the number of
+// elements of type T
+    template<typename T>
+    class scoped_aligned_ptr {
+    public:
+        typedef scoped_aligned_ptr<T> this_type;
+
+        scoped_aligned_ptr() : m_ptr(NULL) {}
+
+        scoped_aligned_ptr(T *ptr) : m_ptr(NULL) { reset(ptr); }
+
+        explicit scoped_aligned_ptr(size_t n) : m_ptr(NULL) { reset(n); }
+
+        ~scoped_aligned_ptr() { reset(); }
+
+        T *get() const { return m_ptr; }
+
+        operator T *() const { return m_ptr; }
+
+        T *operator->() const { return m_ptr; }
+
+        T &operator*() const { return *m_ptr; }
+
+        T &operator[](int index) const { return m_ptr[index]; }
+
+        this_type &operator=(T *ptr) {
+            reset(ptr);
+            return *this;
+        }
+
+        void reset(T *ptr = NULL) {
+            if (m_ptr) alignedFree(m_ptr);
+            m_ptr = ptr;
+        }
+
+        void reset(size_t n) { reset((T *) alignedMalloc(sizeof(T) * n)); }
+
+        T *release() {
+            T *ptr = m_ptr;
+            m_ptr = NULL;
+            return ptr;
+        }
+
+    private:
+        T *m_ptr;
+
+        // noncopyable
+        scoped_aligned_ptr(const this_type &);
+
+        this_type &operator=(const this_type &);
+    };
 }

--- a/src/platform/layerfunctions/convolution/FpgaConvolutionFunction.cpp
+++ b/src/platform/layerfunctions/convolution/FpgaConvolutionFunction.cpp
@@ -26,11 +26,12 @@
 
 #include <iostream>
 #include <fstream>
-
-#include "AOCL_Utils.h"
+#include <cstring>
 
 #include "FpgaConvolutionFunction.h"
-#include "Helper.h"
+#include <ResultException.h>
+#include <ResourceException.h>
+#include <Helper.h>
 
 
 // Threadblock sizes (e.g. for kernels GEMM1 or GEMM2)
@@ -41,111 +42,19 @@
 
 #define WIDTH 4
 
-// =================================================================================================
-
-const char *getErrorString(cl_int error)
-{
-    // LCOV_EXCL_START
-    switch(error){
-        // run-time and JIT compiler errors
-        case 0: return "CL_SUCCESS";
-        case -1: return "CL_DEVICE_NOT_FOUND";
-        case -2: return "CL_DEVICE_NOT_AVAILABLE";
-        case -3: return "CL_COMPILER_NOT_AVAILABLE";
-        case -4: return "CL_MEM_OBJECT_ALLOCATION_FAILURE";
-        case -5: return "CL_OUT_OF_RESOURCES";
-        case -6: return "CL_OUT_OF_HOST_MEMORY";
-        case -7: return "CL_PROFILING_INFO_NOT_AVAILABLE";
-        case -8: return "CL_MEM_COPY_OVERLAP";
-        case -9: return "CL_IMAGE_FORMAT_MISMATCH";
-        case -10: return "CL_IMAGE_FORMAT_NOT_SUPPORTED";
-        case -11: return "CL_BUILD_PROGRAM_FAILURE";
-        case -12: return "CL_MAP_FAILURE";
-        case -13: return "CL_MISALIGNED_SUB_BUFFER_OFFSET";
-        case -14: return "CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST";
-        case -15: return "CL_COMPILE_PROGRAM_FAILURE";
-        case -16: return "CL_LINKER_NOT_AVAILABLE";
-        case -17: return "CL_LINK_PROGRAM_FAILURE";
-        case -18: return "CL_DEVICE_PARTITION_FAILED";
-        case -19: return "CL_KERNEL_ARG_INFO_NOT_AVAILABLE";
-
-            // compile-time errors
-        case -30: return "CL_INVALID_VALUE";
-        case -31: return "CL_INVALID_DEVICE_TYPE";
-        case -32: return "CL_INVALID_PLATFORM";
-        case -33: return "CL_INVALID_DEVICE";
-        case -34: return "CL_INVALID_CONTEXT";
-        case -35: return "CL_INVALID_QUEUE_PROPERTIES";
-        case -36: return "CL_INVALID_COMMAND_QUEUE";
-        case -37: return "CL_INVALID_HOST_PTR";
-        case -38: return "CL_INVALID_MEM_OBJECT";
-        case -39: return "CL_INVALID_IMAGE_FORMAT_DESCRIPTOR";
-        case -40: return "CL_INVALID_IMAGE_SIZE";
-        case -41: return "CL_INVALID_SAMPLER";
-        case -42: return "CL_INVALID_BINARY";
-        case -43: return "CL_INVALID_BUILD_OPTIONS";
-        case -44: return "CL_INVALID_PROGRAM";
-        case -45: return "CL_INVALID_PROGRAM_EXECUTABLE";
-        case -46: return "CL_INVALID_KERNEL_NAME";
-        case -47: return "CL_INVALID_KERNEL_DEFINITION";
-        case -48: return "CL_INVALID_KERNEL";
-        case -49: return "CL_INVALID_ARG_INDEX";
-        case -50: return "CL_INVALID_ARG_VALUE";
-        case -51: return "CL_INVALID_ARG_SIZE";
-        case -52: return "CL_INVALID_KERNEL_ARGS";
-        case -53: return "CL_INVALID_WORK_DIMENSION";
-        case -54: return "CL_INVALID_WORK_GROUP_SIZE";
-        case -55: return "CL_INVALID_WORK_ITEM_SIZE";
-        case -56: return "CL_INVALID_GLOBAL_OFFSET";
-        case -57: return "CL_INVALID_EVENT_WAIT_LIST";
-        case -58: return "CL_INVALID_EVENT";
-        case -59: return "CL_INVALID_OPERATION";
-        case -60: return "CL_INVALID_GL_OBJECT";
-        case -61: return "CL_INVALID_BUFFER_SIZE";
-        case -62: return "CL_INVALID_MIP_LEVEL";
-        case -63: return "CL_INVALID_GLOBAL_WORK_SIZE";
-        case -64: return "CL_INVALID_PROPERTY";
-        case -65: return "CL_INVALID_IMAGE_DESCRIPTOR";
-        case -66: return "CL_INVALID_COMPILER_OPTIONS";
-        case -67: return "CL_INVALID_LINKER_OPTIONS";
-        case -68: return "CL_INVALID_DEVICE_PARTITION_COUNT";
-
-            // extension errors
-        case -1000: return "CL_INVALID_GL_SHAREGROUP_REFERENCE_KHR";
-        case -1001: return "CL_PLATFORM_NOT_FOUND_KHR";
-        case -1002: return "CL_INVALID_D3D10_DEVICE_KHR";
-        case -1003: return "CL_INVALID_D3D10_RESOURCE_KHR";
-        case -1004: return "CL_D3D10_RESOURCE_ALREADY_ACQUIRED_KHR";
-        case -1005: return "CL_D3D10_RESOURCE_NOT_ACQUIRED_KHR";
-        default: return "Unknown OpenCL error";
-    }
-    // LCOV_EXCL_STOP
-}
-
-void CheckError (cl_int error)
-{
-    if (error != CL_SUCCESS) {
-        std::cerr << "OpenCL call failed with error " << getErrorString(error) << std::endl; // LCOV_EXCL_LINE
-        std::exit (1); // LCOV_EXCL_LINE
-    }
-}
-
-
-// =================================================================================================
-
 FpgaConvolutionFunction::FpgaConvolutionFunction(cl_context c, cl_device_id d)
         : context(c), device(d) {
 
     cl_int status = 0;
     queue = clCreateCommandQueue(context, device, 0, &status);
-    aocl_utils::checkError(status, "Failed to create command queue");
+    helper::CheckError<ResourceException>(status, "Failed to create command queue.");
 
-    std::string binary_file = aocl_utils::getBoardBinaryFile(RES_DIR "kernels/gemm4_fpga", device);
-    program = aocl_utils::createProgramFromBinary(context, binary_file.c_str(), &device, 1);
+    std::string binary_file = helper::getBoardBinaryFile(RES_DIR "kernels/gemm4_fpga", device);
+    program = helper::createProgramFromBinary(context, binary_file.c_str(), &device, 1);
 
     // We can't pass runtime parameters to the kernel, so just pass ""
     status = clBuildProgram(program, 0, NULL, "", NULL, NULL);
-    aocl_utils::checkError(status, "Failed to build program");
+    helper::CheckError<ResourceException>(status, "Failed to build program.");
 
     // Check for compilation errors
     size_t logSize;
@@ -219,8 +128,8 @@ void FpgaConvolutionFunction::execute(const DataWrapper &input,
 
     // Bias
     float *D = new float[paddedM];
-    memset(D, 0, paddedM*sizeof(float));
-    memcpy(D, weights.getBiasArray(), number_of_kernels*sizeof(float));
+    std::memset(D, 0, paddedM*sizeof(float));
+    std::memcpy(D, weights.getBiasArray(), number_of_kernels*sizeof(float));
 
 
     // Remember unpadded values, we'll need them again later for the unpadding
@@ -257,7 +166,7 @@ void FpgaConvolutionFunction::execute(const DataWrapper &input,
     const size_t global[2] = { M/WIDTH, N };
     cl_event event;
     cl_int result = clEnqueueNDRangeKernel(queue, kernel, 2, NULL, global, local, 0, NULL, &event);
-    CheckError(result);
+    helper::CheckError<ResultException>(result, "Failed to enqueue kernel.");
 
     // Wait for calculations to be finished
     clWaitForEvents(1, &event);
@@ -269,7 +178,7 @@ void FpgaConvolutionFunction::execute(const DataWrapper &input,
     float *transC = helper::transpose(M, N, C);
     float *unpaddedC = helper::remove_padding(TS, unpaddedN, unpaddedM, transC);
 
-    memcpy(output.getDataArray(), unpaddedC, unpaddedN*unpaddedM*sizeof(float));
+    std::memcpy(output.getDataArray(), unpaddedC, unpaddedN*unpaddedM*sizeof(float));
 
     delete [] transC;
     delete [] unpaddedC;

--- a/src/platform/platforms/ClPlatform.cpp
+++ b/src/platform/platforms/ClPlatform.cpp
@@ -32,8 +32,8 @@
 #include <layerfunctions/pooling/CpuMaxPoolingFunction.h>
 #include <layerfunctions/activation/CpuReLUFunction.h>
 #include <layerfunctions/convolution/ClConvolutionFunction.h>
-
-#include "AOCL_Utils.h"
+#include <Helper.h>
+#include <ResourceException.h>
 
 #include "ClPlatform.h"
 
@@ -99,7 +99,7 @@ void ClPlatform::init() {
     cl_platform_id platform = 0;
 
     status = clGetPlatformIDs(1, &platform, NULL);
-    aocl_utils::checkError(status, "Query for platform ids failed");
+    helper::CheckError<ResourceException>(status, "Query for platform ids failed");
 
     device = 0;
     if(platformInfo.getType() == PlatformType::GPU) {
@@ -107,10 +107,10 @@ void ClPlatform::init() {
     } else if (platformInfo.getType() == PlatformType::CL_CPU) {
         status = clGetDeviceIDs(platform, CL_DEVICE_TYPE_CPU, 1, &device, NULL);
     }
-    aocl_utils::checkError(status, "Query for device ids failed");
+    helper::CheckError<ResourceException>(status, "Query for device ids failed");
 
     context = clCreateContext(NULL, 1, &device, NULL, NULL, &status);
-    aocl_utils::checkError(status, "Failed to create context");
+    helper::CheckError<ResourceException>(status, "Failed to create context");
 }
 
 ClPlatform::~ClPlatform() {
@@ -119,6 +119,3 @@ ClPlatform::~ClPlatform() {
     delete c;
     clReleaseContext(context);
 }
-
-// Make AOCL_Utils happy
-void cleanup() {}; // LCOV_EXCL_LINE


### PR DESCRIPTION
The OpenCL error code alone is not very helpful. It does not return a helpful error message that could be used  for throwing exceptions. Thus we extend the CheckError function to include a second, more descriptive user-defined error message in addition to the original OpenCL error message.

Furthermore, the CheckError function is designed as a template function, so we can also pass the information which kind of exception should be thrown if a OpenCL function was not successful.